### PR TITLE
Fix builtin prefix detection

### DIFF
--- a/traincheck/utils.py
+++ b/traincheck/utils.py
@@ -44,7 +44,7 @@ def typename(o, is_runtime=False):
     if isinstance(prefix, ModuleSpec):
         # handle the case when prefix is a ModuleSpec object
         prefix = prefix.name
-    if prefix in ["buitins", "__builtin__", None]:
+    if prefix in ["builtins", "__builtin__", None]:
         prefix = ""
     is_class_name_qualname = True
     last_name = safe_getattr(o, "__qualname__", "")


### PR DESCRIPTION
## Summary
- fix a typo in `utils.typename` that prevented correct builtins detection

## Testing
- `pre-commit run --files traincheck/utils.py`

------
https://chatgpt.com/codex/tasks/task_e_686785062db0832787dfd1e6bfa642c8